### PR TITLE
Add Pipfile (for pipenv) and requirements.txt (for pip) to make installation a bit less manual.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+pyserial = "*"
+pyqt5 = "*"
+
+[requires]
+python_version = "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyqt5
+pyserial


### PR DESCRIPTION

Right now the installation instructions call out the two python
external dependencies (pyserial and PyQT5), but assumes the dependencies
are installed globally.

I suggest adding a requirements file (and its pipenv equivalent:
Pipfile) so folks can use the normal python installation tools.

This pull request adds those files.  Tested under WSL and Ubuntu 18.