### PR TITLE
Use shortend frequency values in sweep input

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @mihtjel

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,14 +25,8 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+ - Python version: [if applicable]
+ - NanoVNA-Saver version: [e.g. 0.1.4]
 
 **Additional context**
 Add any other context about the problem here.

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -616,11 +616,11 @@ class NanoVNASaver(QtWidgets.QWidget):
             if frequencies:
                 logger.info("Read starting frequency %s and end frequency %s", frequencies[0], frequencies[100])
                 if int(frequencies[0]) == int(frequencies[100]) and (self.sweepStartInput.text() == "" or self.sweepEndInput.text() == ""):
-                    self.sweepStartInput.setText(frequencies[0])
-                    self.sweepEndInput.setText(str(int(frequencies[100]) + 100000))
+                    self.sweepStartInput.setText(RFTools.formatFixedFrequency(int(frequencies[0])))
+                    self.sweepEndInput.setText(RFTools.formatFixedFrequency(int(frequencies[100]) + 100000))
                 elif self.sweepStartInput.text() == "" or self.sweepEndInput.text() == "":
-                    self.sweepStartInput.setText(frequencies[0])
-                    self.sweepEndInput.setText(frequencies[100])
+                    self.sweepStartInput.setText(RFTools.formatFixedFrequency(int(frequencies[0])))
+                    self.sweepEndInput.setText(RFTools.formatFixedFrequency(int(frequencies[100])))
                 self.sweepStartInput.textEdited.emit(self.sweepStartInput.text())
                 self.sweepStartInput.textChanged.emit(self.sweepStartInput.text())
             else:
@@ -759,8 +759,8 @@ class NanoVNASaver(QtWidgets.QWidget):
         fcenter = int(round((fstart+fstop)/2))
         if fspan < 0 or fstart < 0 or fstop < 0:
             return
-        self.sweepSpanInput.setText(str(fspan))
-        self.sweepCenterInput.setText(str(fcenter))
+        self.sweepSpanInput.setText(RFTools.formatFixedFrequency(fspan))
+        self.sweepCenterInput.setText(RFTools.formatFixedFrequency(fcenter))
 
     def updateStartEnd(self):
         fcenter = RFTools.parseFrequency(self.sweepCenterInput.text())
@@ -771,8 +771,8 @@ class NanoVNASaver(QtWidgets.QWidget):
         fstop = int(round(fcenter + fspan/2))
         if fstart < 0 or fstop < 0:
             return
-        self.sweepStartInput.setText(str(fstart))
-        self.sweepEndInput.setText(str(fstop))
+        self.sweepStartInput.setText(RFTools.formatFixedFrequency(fstart))
+        self.sweepEndInput.setText(RFTools.formatFixedFrequency(fstop))
 
     def updateStepSize(self):
         fspan = RFTools.parseFrequency(self.sweepSpanInput.text())
@@ -1888,8 +1888,8 @@ class SweepSettingsWindow(QtWidgets.QWidget):
             start = max(1, start)
             stop += round(span / 10)
 
-        self.app.sweepStartInput.setText(str(start))
-        self.app.sweepEndInput.setText(str(stop))
+        self.app.sweepStartInput.setText(RFTools.formatFixedFrequency(start))
+        self.app.sweepEndInput.setText(RFTools.formatFixedFrequency(stop))
         self.app.sweepEndInput.textEdited.emit(self.app.sweepEndInput.text())
 
     def updateAveraging(self):

--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -13,7 +13,6 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import collections
 import logging
 import math
 import sys

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Latest Release](https://img.shields.io/github/v/release/mihtjel/nanovna-saver.svg)](https://github.com/mihtjel/nanovna-saver/releases/latest)
+[![License](https://img.shields.io/github/license/mihtjel/nanovna-saver.svg)](https://github.com/mihtjel/nanovna-saver/blob/master/LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/mihtjel/nanovna-saver/total.svg)](https://github.com/mihtjel/nanovna-saver/releases/)
+
 NanoVNASaver
 ============
 A multiplatform tool to save Touchstone files from the NanoVNA, sweep frequency spans in segments to gain more than

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     },
     install_requires=[
         'pyserial',
-        'PyQt5==5.11.2',
+        'PyQt5>=5.11.2',
         'numpy',
     ],
 )


### PR DESCRIPTION
I've modified the RFTools frequency parser to cope with more SI prefixes and
added a new formatter to shorten frequency values for easier human readabilities.

73
   DG5DBH