### PR TITLE
Separate formatFrequency for Sweep values

### DIFF
--- a/NanoVNASaver/NanoVNASaver.py
+++ b/NanoVNASaver/NanoVNASaver.py
@@ -631,11 +631,11 @@ class NanoVNASaver(QtWidgets.QWidget):
             if frequencies:
                 logger.info("Read starting frequency %s and end frequency %s", frequencies[0], frequencies[100])
                 if int(frequencies[0]) == int(frequencies[100]) and (self.sweepStartInput.text() == "" or self.sweepEndInput.text() == ""):
-                    self.sweepStartInput.setText(RFTools.formatFixedFrequency(int(frequencies[0])))
-                    self.sweepEndInput.setText(RFTools.formatFixedFrequency(int(frequencies[100]) + 100000))
+                    self.sweepStartInput.setText(RFTools.formatSweepFrequency(int(frequencies[0])))
+                    self.sweepEndInput.setText(RFTools.formatSweepFrequency(int(frequencies[100]) + 100000))
                 elif self.sweepStartInput.text() == "" or self.sweepEndInput.text() == "":
-                    self.sweepStartInput.setText(RFTools.formatFixedFrequency(int(frequencies[0])))
-                    self.sweepEndInput.setText(RFTools.formatFixedFrequency(int(frequencies[100])))
+                    self.sweepStartInput.setText(RFTools.formatSweepFrequency(int(frequencies[0])))
+                    self.sweepEndInput.setText(RFTools.formatSweepFrequency(int(frequencies[100])))
                 self.sweepStartInput.textEdited.emit(self.sweepStartInput.text())
                 self.sweepStartInput.textChanged.emit(self.sweepStartInput.text())
             else:
@@ -786,8 +786,8 @@ class NanoVNASaver(QtWidgets.QWidget):
         fcenter = int(round((fstart+fstop)/2))
         if fspan < 0 or fstart < 0 or fstop < 0:
             return
-        self.sweepSpanInput.setText(RFTools.formatFixedFrequency(fspan))
-        self.sweepCenterInput.setText(RFTools.formatFixedFrequency(fcenter))
+        self.sweepSpanInput.setText(RFTools.formatSweepFrequency(fspan))
+        self.sweepCenterInput.setText(RFTools.formatSweepFrequency(fcenter))
 
     def updateStartEnd(self):
         fcenter = RFTools.parseFrequency(self.sweepCenterInput.text())
@@ -798,8 +798,8 @@ class NanoVNASaver(QtWidgets.QWidget):
         fstop = int(round(fcenter + fspan/2))
         if fstart < 0 or fstop < 0:
             return
-        self.sweepStartInput.setText(RFTools.formatFixedFrequency(fstart))
-        self.sweepEndInput.setText(RFTools.formatFixedFrequency(fstop))
+        self.sweepStartInput.setText(RFTools.formatSweepFrequency(fstart))
+        self.sweepEndInput.setText(RFTools.formatSweepFrequency(fstop))
 
     def updateStepSize(self):
         fspan = RFTools.parseFrequency(self.sweepSpanInput.text())
@@ -2042,8 +2042,8 @@ class SweepSettingsWindow(QtWidgets.QWidget):
             start = max(1, start)
             stop += round(span * padding / 100)
 
-        self.app.sweepStartInput.setText(RFTools.formatFixedFrequency(start))
-        self.app.sweepEndInput.setText(RFTools.formatFixedFrequency(stop))
+        self.app.sweepStartInput.setText(RFTools.formatSweepFrequency(start))
+        self.app.sweepEndInput.setText(RFTools.formatSweepFrequency(stop))
         self.app.sweepEndInput.textEdited.emit(self.app.sweepEndInput.text())
 
     def updateAveraging(self):

--- a/NanoVNASaver/RFTools.py
+++ b/NanoVNASaver/RFTools.py
@@ -130,11 +130,51 @@ class RFTools:
 
         if freq < 1:
             return " - " + (" " if insertSpace else "") + ("Hz" if appendHz else "")
+
+        freqstr = str(freq)
+        freqlen = len(freqstr)
         si_index = (freqlen - 1) // 3
         dot_pos = freqlen % 3 or 3
         freqstr = freqstr[:dot_pos] + "." + freqstr[dot_pos:] + "00"
+        retval = freqstr[:maxdigits] + (" " if insertSpace else "") + PREFIXES[si_index] + ("Hz" if appendHz else "")
+        return retval
 
-        return freqstr[:maxdigits] + (" " if insertSpace else "") + PREFIXES[si_index] + ("Hz" if appendHz else "")
+    @staticmethod
+    def formatSweepFrequency(freq: int,
+                             mindigits: int = 0,
+                             appendHz: bool = True,
+                             insertSpace: bool = False,
+                             countDot: bool = True,
+                             assumeInfinity: bool = True) -> str:
+        """ Format frequency with SI prefixes
+
+            mindigits count refers to the number of decimal place digits
+            that will be shown, padded with zeroes if needed.
+        """
+        freqstr = str(freq)
+        freqlen = len(freqstr)
+
+        # sanity checks
+        if freqlen > 15:
+            if assumeInfinity:
+                return "\N{INFINITY}"
+            raise ValueError("Frequency to big. More than 15 digits!")
+
+        if freq < 1:
+            return " - " + (" " if insertSpace else "") + ("Hz" if appendHz else "")
+
+        si_index = (freqlen - 1) // 3
+        dot_pos = freqlen % 3 or 3
+        intfstr = freqstr[:dot_pos]
+        decfstr = freqstr[dot_pos:]
+        nzdecfstr = decfstr.rstrip('0')
+        nzdecfstrlen = len(nzdecfstr)
+        if si_index != 0:
+            while (len(nzdecfstr) < mindigits): nzdecfstr += '0'
+        freqstr = intfstr + ("." if len(nzdecfstr) > 0 else "") + nzdecfstr
+        retval = freqstr + (" " if insertSpace else "") + PREFIXES[si_index] + ("Hz" if appendHz else "")
+        return retval
+
 
     @staticmethod
     def parseFrequency(freq: str) -> int:


### PR DESCRIPTION
formatFixedFrequency limits the maximum digits displayed to fit return values within space available. For sweep frequencies this can result in loss of accuracy. formatSweepFrequency instead provides the smallest return value that does not result in loss of accuracy, but allows for padding trailing zeroes if desired.