### PR TITLE
Use python native complex numbers in RFTools

### DIFF
--- a/NanoVNASaver/RFTools.py
+++ b/NanoVNASaver/RFTools.py
@@ -41,6 +41,11 @@ class Datapoint(NamedTuple):
         """ return datapoint impedance as complex number """
         return complex(self.re, self.im)
 
+    @property
+    def phase(self):
+        """ return datapoints phase value """
+        return cmath.phase(self.z)
+
     def as_gain(self) -> float:
         mag = abs(self.z)
         if mag > 0:
@@ -141,17 +146,13 @@ class RFTools:
 
     @staticmethod
     def groupDelay(data: List[Datapoint], index: int) -> float:
-        index0 = clamp_int(index - 1, 0, len(data) - 1)
-        index1 = clamp_int(index + 1, 0, len(data) - 1)
-        angle0 = cmath.phase(data[index0].z)
-        angle1 = cmath.phase(data[index1].z)
-        freq0 = data[index0].freq
-        freq1 = data[index1].freq
-        delta_angle = (angle1 - angle0)
+        idx0 = clamp_int(index - 1, 0, len(data) - 1)
+        idx1 = clamp_int(index + 1, 0, len(data) - 1)
+        delta_angle = (data[idx1].phase - data[idx0].phase)
         if abs(delta_angle) > math.tau:
             if delta_angle > 0:
                 delta_angle = delta_angle % math.tau
             else:
                 delta_angle = -1 * (delta_angle % math.tau)
-        val = -delta_angle / math.tau / (freq1 - freq0)
+        val = -delta_angle / math.tau / (data[idx1].freq - data[idx0].freq)
         return val

--- a/NanoVNASaver/RFTools.py
+++ b/NanoVNASaver/RFTools.py
@@ -29,6 +29,10 @@ def clamp_int(value: int, imin: int, imax: int) -> int:
     return value
 
 
+def gamma_to_impedance(gamma: complex, impedance: float) -> complex:
+    return impedance * ((-gamma - 1) / (gamma - 1))
+
+
 class Datapoint(NamedTuple):
     freq: int
     re: float
@@ -42,7 +46,7 @@ class Datapoint(NamedTuple):
 class RFTools:
     @staticmethod
     def normalize50(data: Datapoint):
-        result = 50 * ((-data.z - 1) / (data.z - 1))
+        result = gamma_to_impedance(data.z, 50)
         return result.real, result.imag
 
     @staticmethod
@@ -54,16 +58,13 @@ class RFTools:
 
     @staticmethod
     def qualityFactor(data: Datapoint):
-        re50, im50 = RFTools.normalize50(data)
-        if re50 != 0:
-            Q = abs(im50 / re50)
-        else:
-            Q = -1
-        return Q
+        imp = gamma_to_impedance(data.z, 50)
+        if imp.real != 0.0:
+            return abs(imp.imag / imp.real)
+        return -1
 
     @staticmethod
     def calculateVSWR(data: Datapoint):
-        # re50, im50 = normalize50(data)
         try:
             mag = abs(data.z)
             vswr = (1 + mag) / (1 - mag)


### PR DESCRIPTION
I've modified Datapoint to supply optional native python complex numbers via a z impedance property
and used cmath for RFTool calculations